### PR TITLE
Minor updates to newmember

### DIFF
--- a/src/avionics/software/newmember.md
+++ b/src/avionics/software/newmember.md
@@ -58,18 +58,14 @@ sudo apt install git cmake default-jre python3 python3-pip python3-venv
 We can now begin the virtual enviroment creation
 
 
-```shell
-python3 -m pip install --user virtualenv
-```
-
 > A virtual enviroment (venv) allows for different packages to be installed at different versions within python and mitigate version conflict errors
 
-We now pick a location to install the virtual enviroment, for the purposes of this guide we will use the `$HOME` directory as our root. If you would rather use another location feel free.
+Pick a location to install the virtual enviroment. For the purposes of this guide we will use the `$HOME` directory as our root. If you would rather use another location feel free.
 
 ```bash
 python3 -m venv $HOME/fprime-venv
-source $HOME/fprime-venv/bin/activate
-pip install -U setuptools setuptools_scm wheel pip
+. $HOME/fprime-venv/bin/activate
+pip install -U setuptools setuptools_scm wheel
 ```
 
 The first command creates the venv, the second command activates the venv, and the third command installs some needed packages.
@@ -86,9 +82,9 @@ To exit the virtual enviroment simply enter `deactivate` while the venv is activ
 > linux users will need to modifly the file `~/.bashrc` 
 > Add the following line at the end of the file and save
 > ```sh
-> alias fpvenv="source $HOME/fprime-venv/bin/activate"
+> alias fpvenv=". $HOME/fprime-venv/bin/activate"
 >```
-> Ensure to update your terminal with `source ~/.zshrc`
+> Ensure to update your terminal with `. ~/.zshrc`
 > Now typing fpvenv will activate your virtual enviroment
 
 
@@ -173,7 +169,7 @@ In your prefered directory(`$HOME` or `Desktop` is recomended) clone the srl FPr
 ```bash
 git clone git@github.com:CU-SRL/srlFp.git
 cd srlFp
-pip install -r fprime/requirements.txt
+pip install -r requirements.txt
 ```
 
 #### Verify install

--- a/src/avionics/software/newmember.md
+++ b/src/avionics/software/newmember.md
@@ -65,7 +65,7 @@ Pick a location to install the virtual enviroment. For the purposes of this guid
 ```bash
 python3 -m venv $HOME/fprime-venv
 . $HOME/fprime-venv/bin/activate
-pip install -U setuptools setuptools_scm wheel
+pip install -U setuptools setuptools_scm wheel pip
 ```
 
 The first command creates the venv, the second command activates the venv, and the third command installs some needed packages.


### PR DESCRIPTION
The updates I made:
- Removed "python3 -m pip install --user virtualenv" because virtualenv is not used, only venv. Venv is installed in the previous command. I also slightly updated the instructions around it so that the context still makes sense without that command.
- I changed the "source" command to "." since they mean the same thing in bash, but some sh shells don't have "source" and only have "." I did this in the 3 locations source is used
- For some reason pip installs itself? It is fine to keep it and pip may just update itself, just kinda weird. I removed it but on second thought we should probably just keep this in.
- I changed "pip install -r fprime/requirements.txt" to "pip install -r requirements.txt" because the previous command already cd into srlFp. (fprime/requirements.txt doesn't exist, the requirements file is just under srlFp).